### PR TITLE
Remove Python 3.5 requirement

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,6 @@ numpy = "*"
 [dev-packages]
 
 
-
 [requires]
 
-python_version = "3.5"
+


### PR DESCRIPTION
No way to specify version >3.5 in Pipfile