### PR TITLE
Use custom image for VAMPyR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 variables:
   ubuntu-1804: &ubuntu-1804
     docker:
-      - image: mrchemsoft/circleci_ubuntu-18.04
+      - image: mrchemsoft/circleci_vampyr_ubuntu-18.04
         name: tsubame
         user: merzbow
     working_directory: ~/vampyr

--- a/.circleci/run_commands
+++ b/.circleci/run_commands
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Install recent CMake
-CMAKE_VERSION="3.12.1"
+CMAKE_VERSION="3.11.4"
 cmake_url="https://cmake.org/files/v${CMAKE_VERSION%.*}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz"
 target_path="/opt/cmake"
 mkdir -p $target_path && \


### PR DESCRIPTION
I've created a new Docker image for VAMPyR. Locally, it fixes #11 and hopefully it does the same non-locally.

#### Note
The image uses the latest version of CMake 3.11 I didn't set it up to use 3.12 (or 3.13) because in this way we make sure we don't break the minimum required version specified in `CMakeLists.txt`
Note that the Docker image is _not rebuilt_ with a push to this repo. Rather, it's built locally separately and then uploaded. Depending on me (or any one person!) for this to happen doesn't scale. I suggest we open a "meta" repository to host the Docker files and set up automated builds on Dockerhub.