### PR TITLE
Fix bindings for Gaussian inheritance hierarchy

### DIFF
--- a/cmake/custom/external.cmake
+++ b/cmake/custom/external.cmake
@@ -37,7 +37,7 @@ endif()
 set(STAGED_INSTALL_PREFIX ${CMAKE_BINARY_DIR}/stage)
 message(STATUS "${PROJECT_NAME} staged install: ${STAGED_INSTALL_PREFIX}")
 
-find_package(MRCPP 1.3 CONFIG QUIET)
+find_package(MRCPP 1.3.5 CONFIG QUIET)
 if(TARGET MRCPP::mrcpp)
   get_property(_loc TARGET MRCPP::mrcpp PROPERTY LOCATION)
   message(STATUS "Found MRCPP: ${_loc} (found version ${MRCPP_VERSION})")
@@ -46,7 +46,7 @@ else()
   FetchContent_Declare(mrcpp_sources
     QUIET
     URL
-      https://github.com/MRChemSoft/mrcpp/archive/v1.3.4.tar.gz
+      https://github.com/MRChemSoft/mrcpp/archive/v1.3.5.tar.gz
     )
 
   FetchContent_GetProperties(mrcpp_sources)

--- a/vampyr/PyRepresentableFunction.h
+++ b/vampyr/PyRepresentableFunction.h
@@ -22,7 +22,6 @@ public:
     double evalf(const mrcpp::Coord<D> &r) const override { PYBIND11_OVERLOAD_PURE(double, FunctionBase, evalf, r); }
 };
 
-// NOTE The following is currently not used
 template <int D, class GaussianBase = mrcpp::Gaussian<D>>
 class PyGaussian : public PyRepresentableFunction<D, GaussianBase> {
 public:
@@ -30,7 +29,7 @@ public:
     using PyRepresentableFunction<D, GaussianBase>::PyRepresentableFunction;
 
     GaussianBase *copy() const override { PYBIND11_OVERLOAD_PURE(GaussianBase *, GaussianBase, copy, ); }
-    double evalf(const mrcpp::Coord<D> &r) const override { PYBIND11_OVERLOAD_PURE(double, GaussianBase, evalf, r); }
+    double evalfCore(const mrcpp::Coord<D> &r) const override { PYBIND11_OVERLOAD_PURE(double, GaussianBase, evalfCore, r); }
     double evalf(double r, int dim) const override { PYBIND11_OVERLOAD_PURE(double, GaussianBase, evalf, r, dim); }
     double calcSquareNorm() override { PYBIND11_OVERLOAD_PURE(double, GaussianBase, calcSquareNorm, ); }
     double calcOverlap(mrcpp::GaussFunc<D> &b) override {

--- a/vampyr/bases/bases.cpp
+++ b/vampyr/bases/bases.cpp
@@ -13,20 +13,21 @@
 
 using namespace mrcpp;
 namespace py = pybind11;
+using namespace pybind11::literals;
 
 namespace vampyr {
 
 void bases(py::module &m) {
 
-    py::class_<ScalingBasis> scalingbasis(m, "ScalingBasis");
-    scalingbasis.def(py::init<int, int>());
+  py::class_<ScalingBasis>(m, "ScalingBasis")
+    .def(py::init<int, int>(), "order"_a, "type"_a);
 
-    py::class_<InterpolatingBasis>(m, "InterpolatingBasis", scalingbasis)
-        .def(py::init<int>())
+    py::class_<InterpolatingBasis, ScalingBasis>(m, "InterpolatingBasis")
+        .def(py::init<int>(), "order"_a)
         .def("getScalingOrder", &InterpolatingBasis::getScalingOrder);
 
-    py::class_<LegendreBasis>(m, "LegendreBasis", scalingbasis)
-        .def(py::init<int>())
+    py::class_<LegendreBasis, ScalingBasis>(m, "LegendreBasis")
+        .def(py::init<int>(), "order"_a)
         .def("getScalingOrder", &LegendreBasis::getScalingOrder);
 }
 } // namespace vampyr

--- a/vampyr/export_vampyr.cpp
+++ b/vampyr/export_vampyr.cpp
@@ -51,13 +51,13 @@ template <int D> void bind_mr(py::module &mod) noexcept {
 
 PYBIND11_MODULE(_vampyr, m) {
     using namespace mrcpp;
-    m.doc() = "VAMPyR makes the MRCPP functionality available through a python interface";
+    m.doc() = "VAMPyR makes the MRCPP functionality available through a Python interface";
 
     // Dimension-independent bindings go in the main module
     bases(m);
 
-    py::class_<BandWidth> bandwidth(m, "BandWidth");
-    bandwidth.def(py::init<int>())
+    py::class_<BandWidth>(m, "BandWidth")
+        .def(py::init<int>())
         .def("clear", &BandWidth::clear)
         .def("isEmpty", &BandWidth::isEmpty)
         .def("getDepth", &BandWidth::getDepth)

--- a/vampyr/functions/GaussFunc.h
+++ b/vampyr/functions/GaussFunc.h
@@ -12,7 +12,7 @@ template <int D> void gauss_func(pybind11::module &m) {
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    py::class_<GaussFunc<D>, Gaussian<D>>(m, "GaussFunc")
+    py::class_<GaussFunc<D>, PyGaussian<D, GaussFunc<D>>, Gaussian<D>>(m, "GaussFunc")
         .def(py::init<double, double, Coord<D> &, std::array<int, D> &>(),
              "alpha"_a,
              "beta"_a,

--- a/vampyr/functions/GaussPoly.h
+++ b/vampyr/functions/GaussPoly.h
@@ -16,7 +16,7 @@ template <int D> void gauss_poly(pybind11::module &m) {
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    py::class_<GaussPoly<D>, Gaussian<D>>(m, "GaussPoly")
+    py::class_<GaussPoly<D>, PyGaussian<D, GaussPoly<D>>, Gaussian<D>>(m, "GaussPoly")
         .def(pybind11::init<double, double, const Coord<D> &, const std::array<int, D> &>())
         .def("setPoly", &GaussPoly<D>::setPoly)
         .def("differentiate", &GaussPoly<D>::differentiate)

--- a/vampyr/functions/functions.h
+++ b/vampyr/functions/functions.h
@@ -31,21 +31,19 @@ template <int D> void functions(pybind11::module &m) {
     analytic_function<D>(m);
     gauss_exp<D>(m);
 
-    py::class_<Gaussian<D>, RepresentableFunction<D>>(m, "Gaussian");
-    // FIXME These cannot currently be bound due to confusion with inheritance hierarchies.
-    //    .def(py::init<double, double, const Coord<D> &, const std::array<int, D> &>(), "a"_a, "c"_a, "r"_a, "p"_a)
-    //.def(py::init<const std ::array<double, D> &, double, const Coord<D> &, const std::array<int, D> &>(),
-    //     "a"_a,
-    //     "c"_a,
-    //     "r"_a,
-    //     "p"_a)
-    //.def("evalf", py::overload_cast<const Coord<D>&>(&Gaussian<D>::evalf, py::const_))
-    // Bind the other crap
-    //.def("__str__", [](const Gaussian<D> &obj) {
-    //    std::ostringstream os;
-    //    os << obj;
-    //    return os.str();
-    //});
+    py::class_<Gaussian<D>, PyGaussian<D>, RepresentableFunction<D>>(m, "Gaussian")
+        .def(py::init<double, double, const Coord<D> &, const std::array<int, D> &>(), "a"_a, "c"_a, "r"_a, "p"_a)
+        .def(py::init<const std ::array<double, D> &, double, const Coord<D> &, const std::array<int, D> &>(),
+             "a"_a,
+             "c"_a,
+             "r"_a,
+             "p"_a)
+        .def("evalf", py::overload_cast<const Coord<D>&>(&Gaussian<D>::evalf, py::const_))
+        .def("__str__", [](const Gaussian<D> &obj) {
+            std::ostringstream os;
+            os << obj;
+            return os.str();
+        });
     gauss_func<D>(m);
     gauss_poly<D>(m);
 }

--- a/vampyr/operators/MWOperator.h
+++ b/vampyr/operators/MWOperator.h
@@ -11,8 +11,8 @@ void mw_operator(pybind11::module &m) {
     namespace py = pybind11;
 
     //MWOperator
-    py::class_<MWOperator> mwoperator(m, "MWOperator");
-    mwoperator.def(py::init<const MultiResolutionAnalysis<2> &>())
+    py::class_<MWOperator>(m, "MWOperator")
+        .def(py::init<const MultiResolutionAnalysis<2> &>())
         .def("size", &MWOperator::size, "Size")
         .def("push_back", &MWOperator::push_back, "Push")
         .def("clear", &MWOperator::clear, "Clear")


### PR DESCRIPTION
This follows advice given here: https://github.com/pybind/pybind11/issues/2064#issuecomment-691535995 and requires to remove the `final` qualifier from `GaussFunc` and `GaussPoly` in MRCPP to work properly.