### PR TITLE
Add deepCopy and arithmetic operator overloads

### DIFF
--- a/tests/test_arithmetics_1d.py
+++ b/tests/test_arithmetics_1d.py
@@ -119,3 +119,67 @@ def test_Multiplication():
     tree_9.power(pow=2.0)
     assert tree_9.getNNodes() == tree_1.getNNodes()
     assert tree_9.integrate() == pytest.approx(tree_1.getSquareNorm(), rel=epsilon)
+
+def test_OverloadedOperators():
+    tree_1 = vp.FunctionTree(mra)
+    vp.build_grid(out=tree_1, inp=gauss)
+    vp.project(out=tree_1, inp=gauss)
+    ref_int = tree_1.integrate()
+    ref_norm = tree_1.getSquareNorm()
+    ref_nodes = tree_1.getNNodes()
+
+    tree_2 = +tree_1
+    assert tree_2.getNNodes() == ref_nodes
+    assert tree_2.integrate() == pytest.approx(ref_int, rel=epsilon)
+
+    tree_2 *= -2.0
+    assert tree_2.getNNodes() == ref_nodes
+    assert tree_2.integrate() == pytest.approx(-2.0*ref_int, rel=epsilon)
+
+    tree_3 = -tree_1
+    assert tree_3.getNNodes() == ref_nodes
+    assert tree_3.integrate() == pytest.approx(-ref_int, rel=epsilon)
+
+    tree_3 /= 2.0
+    assert tree_3.getNNodes() == ref_nodes
+    assert tree_3.integrate() == pytest.approx(-0.5*ref_int, rel=epsilon)
+
+    tree_3 *= tree_2
+    assert tree_3.getNNodes() > ref_nodes
+    assert tree_3.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_4 = tree_1*2.0
+    assert tree_4.getNNodes() == ref_nodes
+    assert tree_4.integrate() == pytest.approx(2.0*ref_int, rel=epsilon)
+
+    tree_5 = 2.0*tree_1
+    assert tree_5.getNNodes() == ref_nodes
+    assert tree_5.integrate() == pytest.approx(2.0*ref_int, rel=epsilon)
+
+    tree_6 = tree_1/2.0 + 1.5*tree_1
+    assert tree_6.getNNodes() == ref_nodes
+    assert tree_6.integrate() == pytest.approx(2.0*ref_int, rel=epsilon)
+
+    tree_6 += tree_1
+    assert tree_6.getNNodes() == ref_nodes
+    assert tree_6.integrate() == pytest.approx(3.0*ref_int, rel=epsilon)
+
+    tree_6 -= 2.0*tree_4
+    assert tree_6.getNNodes() == ref_nodes
+    assert tree_6.integrate() == pytest.approx(-1.0*ref_int, rel=epsilon)
+
+    tree_6 **= 2.0
+    assert tree_6.getNNodes() > ref_nodes
+    assert tree_6.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_7 = tree_1 - tree_2
+    assert tree_7.getNNodes() == ref_nodes
+    assert tree_7.integrate() == pytest.approx(3.0*ref_int, rel=epsilon)
+
+    tree_8 = tree_1**2.0
+    assert tree_8.getNNodes() > ref_nodes
+    assert tree_8.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_9 = tree_1 * tree_1
+    assert tree_9.getNNodes() > ref_nodes
+    assert tree_9.integrate() == pytest.approx(ref_norm, rel=epsilon)

--- a/tests/test_arithmetics_1d.py
+++ b/tests/test_arithmetics_1d.py
@@ -183,3 +183,8 @@ def test_OverloadedOperators():
     tree_9 = tree_1 * tree_1
     assert tree_9.getNNodes() > ref_nodes
     assert tree_9.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_10 = (tree_1 * tree_1).crop(epsilon) + (tree_1**2).crop(epsilon)
+    assert tree_10.getNNodes() > tree_1.getNNodes()
+    assert tree_10.getNNodes() < tree_9.getNNodes()
+    assert tree_10.integrate() == pytest.approx(2.0*ref_norm, rel=epsilon)

--- a/tests/test_arithmetics_3d.py
+++ b/tests/test_arithmetics_3d.py
@@ -119,3 +119,67 @@ def test_Multiplication():
     tree_9.power(pow=2.0)
     assert tree_9.getNNodes() == tree_1.getNNodes()
     assert tree_9.integrate() == pytest.approx(tree_1.getSquareNorm(), rel=epsilon)
+
+def test_OverloadedOperators():
+    tree_1 = vp.FunctionTree(mra)
+    vp.build_grid(out=tree_1, inp=gauss)
+    vp.project(out=tree_1, inp=gauss)
+    ref_int = tree_1.integrate()
+    ref_norm = tree_1.getSquareNorm()
+    ref_nodes = tree_1.getNNodes()
+
+    tree_2 = +tree_1
+    assert tree_2.getNNodes() == ref_nodes
+    assert tree_2.integrate() == pytest.approx(ref_int, rel=epsilon)
+
+    tree_2 *= -2.0
+    assert tree_2.getNNodes() == ref_nodes
+    assert tree_2.integrate() == pytest.approx(-2.0*ref_int, rel=epsilon)
+
+    tree_3 = -tree_1
+    assert tree_3.getNNodes() == ref_nodes
+    assert tree_3.integrate() == pytest.approx(-ref_int, rel=epsilon)
+
+    tree_3 /= 2.0
+    assert tree_3.getNNodes() == ref_nodes
+    assert tree_3.integrate() == pytest.approx(-0.5*ref_int, rel=epsilon)
+
+    tree_3 *= tree_2
+    assert tree_3.getNNodes() > ref_nodes
+    assert tree_3.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_4 = tree_1*2.0
+    assert tree_4.getNNodes() == ref_nodes
+    assert tree_4.integrate() == pytest.approx(2.0*ref_int, rel=epsilon)
+
+    tree_5 = 2.0*tree_1
+    assert tree_5.getNNodes() == ref_nodes
+    assert tree_5.integrate() == pytest.approx(2.0*ref_int, rel=epsilon)
+
+    tree_6 = tree_1/2.0 + 1.5*tree_1
+    assert tree_6.getNNodes() == ref_nodes
+    assert tree_6.integrate() == pytest.approx(2.0*ref_int, rel=epsilon)
+
+    tree_6 += tree_1
+    assert tree_6.getNNodes() == ref_nodes
+    assert tree_6.integrate() == pytest.approx(3.0*ref_int, rel=epsilon)
+
+    tree_6 -= 2.0*tree_4
+    assert tree_6.getNNodes() == ref_nodes
+    assert tree_6.integrate() == pytest.approx(-1.0*ref_int, rel=epsilon)
+
+    tree_6 **= 2.0
+    assert tree_6.getNNodes() > ref_nodes
+    assert tree_6.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_7 = tree_1 - tree_2
+    assert tree_7.getNNodes() == ref_nodes
+    assert tree_7.integrate() == pytest.approx(3.0*ref_int, rel=epsilon)
+
+    tree_8 = tree_1**2.0
+    assert tree_8.getNNodes() > ref_nodes
+    assert tree_8.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_9 = tree_1 * tree_1
+    assert tree_9.getNNodes() > ref_nodes
+    assert tree_9.integrate() == pytest.approx(ref_norm, rel=epsilon)

--- a/tests/test_arithmetics_3d.py
+++ b/tests/test_arithmetics_3d.py
@@ -183,3 +183,8 @@ def test_OverloadedOperators():
     tree_9 = tree_1 * tree_1
     assert tree_9.getNNodes() > ref_nodes
     assert tree_9.integrate() == pytest.approx(ref_norm, rel=epsilon)
+
+    tree_10 = (tree_1 * tree_1).crop(epsilon) + (tree_1**2).crop(epsilon)
+    assert tree_10.getNNodes() > tree_1.getNNodes()
+    assert tree_10.getNNodes() < tree_9.getNNodes()
+    assert tree_10.integrate() == pytest.approx(2.0*ref_norm, rel=epsilon)

--- a/tests/test_grids_and_project_1d.py
+++ b/tests/test_grids_and_project_1d.py
@@ -112,7 +112,7 @@ def test_ClearProjectRefine():
         assert tree.getSquareNorm() > 0.0
     assert tree.integrate() == pytest.approx(1.0, rel=epsilon)
 
-def test_ProjectRescaleNormalize():
+def test_ProjectRescaleCopyNormalize():
     tree = vp.FunctionTree(mra)
     vp.build_grid(out=tree, inp=gauss)
     vp.project(out=tree, inp=gauss)
@@ -121,8 +121,15 @@ def test_ProjectRescaleNormalize():
     tree.rescale(coef=np.pi)
     assert tree.integrate() == pytest.approx(np.pi, rel=epsilon)
 
+    tree_shallow = tree
+    tree_deep = tree.deepCopy()
+    assert tree_shallow.integrate() == pytest.approx(np.pi, rel=epsilon)
+    assert tree_deep.integrate() == pytest.approx(np.pi, rel=epsilon)
+
     tree.normalize()
     assert tree.getSquareNorm() == pytest.approx(1.0, rel=epsilon)
+    assert tree_deep.integrate() == pytest.approx(np.pi, rel=epsilon)
+    assert tree_shallow.integrate() != pytest.approx(np.pi, rel=epsilon)
 
 def test_BuildProjectSemiPeriodicGauss():
     sfac = [np.pi/3]

--- a/tests/test_grids_and_project_3d.py
+++ b/tests/test_grids_and_project_3d.py
@@ -112,7 +112,7 @@ def test_ClearProjectRefine():
         assert tree.getSquareNorm() > 0.0
     assert tree.integrate() == pytest.approx(1.0, rel=epsilon)
 
-def test_ProjectRescaleNormalize():
+def test_ProjectRescaleCopyNormalize():
     tree = vp.FunctionTree(mra)
     vp.build_grid(out=tree, inp=gauss)
     vp.project(out=tree, inp=gauss)
@@ -121,8 +121,15 @@ def test_ProjectRescaleNormalize():
     tree.rescale(coef=np.pi)
     assert tree.integrate() == pytest.approx(np.pi, rel=epsilon)
 
+    tree_shallow = tree
+    tree_deep = tree.deepCopy()
+    assert tree_shallow.integrate() == pytest.approx(np.pi, rel=epsilon)
+    assert tree_deep.integrate() == pytest.approx(np.pi, rel=epsilon)
+
     tree.normalize()
     assert tree.getSquareNorm() == pytest.approx(1.0, rel=epsilon)
+    assert tree_deep.integrate() == pytest.approx(np.pi, rel=epsilon)
+    assert tree_shallow.integrate() != pytest.approx(np.pi, rel=epsilon)
 
 def test_BuildProjectSemiPeriodicGauss():
     sfac = [np.pi/3, np.pi/3, np.pi/3]

--- a/vampyr/trees/trees.h
+++ b/vampyr/trees/trees.h
@@ -40,13 +40,16 @@ template <int D> void trees(pybind11::module &m) {
         .def("integrate", &FunctionTree<D>::integrate)
         .def("normalize", &FunctionTree<D>::normalize)
         .def("rescale", &FunctionTree<D>::rescale, "coef"_a)
-        .def("crop", &FunctionTree<D>::crop, "prec"_a, "split_fac"_a=1.0, "abs_prec"_a=false)
         .def("add", &FunctionTree<D>::add, "coef"_a=1.0, "inp"_a)
         .def("multiply", &FunctionTree<D>::multiply, "coef"_a=1.0, "inp"_a)
         .def("square", &FunctionTree<D>::square)
         .def("power", &FunctionTree<D>::power, "pow"_a)
         .def("saveTree", &FunctionTree<D>::saveTree, "filename"_a)
         .def("loadTree", &FunctionTree<D>::loadTree, "filename"_a)
+        .def("crop", [](FunctionTree<D> *out, double prec, bool abs_prec) {
+                out->crop(prec, 1.0, abs_prec);
+                return out;
+            }, "prec"_a, "abs_prec"_a=false)
         .def("deepCopy", [](FunctionTree<D> *inp) {
                 auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
                 copy_grid(*out, *inp);


### PR DESCRIPTION
I think I covered all relevant possibilities:

- `tree_a = tree_b.deepCopy()`
- `tree_a = tree_b` (shallow copy)
- `tree_a = +tree_b` (deep copy)
- `tree_a = -tree_b` (deep copy with sign change)
- `tree_a *= 2.0`
- `tree_a /= 2.0`
- `tree_a **= 2.0`
- `tree_a *= tree_b`
- `tree_a += tree_b`
- `tree_a -= tree_b`
- `tree_a = tree_b**2.0`
- `tree_a = 2.0*tree_b`
- `tree_a = tree_b*2.0`
- `tree_a = tree_b/2.0`
- `tree_a = tree_b + tree_c`
- `tree_a = tree_b - tree_c`
- `tree_a = tree_b * tree_c`

And of course any combination of the above:
- `tree_a -= 2.0*(tree_b + tree_c/2.0) - tree_d**2.0 + tree_e*tree_f`

The arithmetics are always done in the "correct" way in terms of precision, but not necessarily in terms of efficiency. There is no precision parameter in these operations, but the grid size of the output is always `>=` the grids of the input function(s). Additions will build union grids, while multiplications will build _one level deeper_ than union grid, i.e. grids can grow significantly with time, or in long expressions as the one above. We thus have to make manual use of the `crop(prec)` function in order to retain a manageable grid size. We can then crop the intermediates in the following way to keep precision at each step:

- `tree_a -= 2.0*(tree_b + tree_c/2.0).crop(prec) - (tree_d**2.0).crop(prec) + (tree_e*tree_f).crop(prec)`


Had to make use of pointer `inout` arguments and `std::unique_ptr<FunctionTree<D>>` return values because the trees are non-copyable, but I think (hope) this is kosher :crossed_fingers: 