### PR TITLE
Link  to `stdc++fs` on GCC<9.1 and LLVM<9.0

### DIFF
--- a/src/vampyr/CMakeLists.txt
+++ b/src/vampyr/CMakeLists.txt
@@ -17,7 +17,11 @@ target_link_libraries(_vampyr
   PUBLIC
     MRCPP::mrcpp
   PRIVATE
-    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>"    
+    # extra linking needed to use std::filesystem: https://en.cppreference.com/w/cpp/filesystem
+    # need to link against stdc++fs for GNU<9.1
+    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.1>>:-lstdc++fs>"
+    # need to link against c++fs for LLVM<9.0
+    "$<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lc++fs>"
   )
   
 target_link_options(_vampyr

--- a/src/vampyr/CMakeLists.txt
+++ b/src/vampyr/CMakeLists.txt
@@ -23,11 +23,6 @@ target_link_libraries(_vampyr
     # need to link against c++fs for LLVM<9.0
     "$<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lc++fs>"
   )
-  
-target_link_options(_vampyr
-  PRIVATE
-    "LINKER:--as-needed"
-  )
 
 # handle RPATH
 set(_plat_token "")

--- a/src/vampyr/CMakeLists.txt
+++ b/src/vampyr/CMakeLists.txt
@@ -16,6 +16,13 @@ target_include_directories(_vampyr
 target_link_libraries(_vampyr
   PUBLIC
     MRCPP::mrcpp
+  PRIVATE
+    "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>"    
+  )
+  
+target_link_options(_vampyr
+  PRIVATE
+    "LINKER:--as-needed"
   )
 
 # handle RPATH


### PR DESCRIPTION
As noted [here](https://en.cppreference.com/w/cpp/filesystem) in the **Notes** section, using `std::filesystem` on older GCC/Clang requires some extra libraries to be linked in. This should fix #89 @bjorgve please try it out on `woolf` before merging.