### PR TITLE
Add quadrature to MWNode and FunctionTree

### DIFF
--- a/src/vampyr/trees/trees.h
+++ b/src/vampyr/trees/trees.h
@@ -3,7 +3,7 @@
 #include <filesystem>
 
 #include <pybind11/stl/filesystem.h>
-#include <pybind11/Eigen.h>
+#include <pybind11/eigen.h>
 
 #include <MRCPP/trees/FunctionNode.h>
 #include <MRCPP/trees/FunctionTree.h>

--- a/src/vampyr/trees/trees.h
+++ b/src/vampyr/trees/trees.h
@@ -62,6 +62,10 @@ template <int D> void trees(pybind11::module &m) {
         .def("quadrature",
              [](FunctionTree<D> *tree) {
 
+                if constexpr (D != 1) {
+                    throw std::runtime_error("quadrature only implemented for 1D");
+                }
+
                 // Current implementation only makes sense in 1D
 
                 std::vector<double> vec_pts;

--- a/src/vampyr/trees/trees.h
+++ b/src/vampyr/trees/trees.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 
 #include <pybind11/stl/filesystem.h>
+#include <pybind11/Eigen.h>
 
 #include <MRCPP/trees/FunctionNode.h>
 #include <MRCPP/trees/FunctionTree.h>
@@ -58,6 +59,29 @@ template <int D> void trees(pybind11::module &m) {
         .def("nGenNodes", &FunctionTree<D>::getNGenNodes)
         .def("deleteGenerated", &FunctionTree<D>::deleteGenerated)
         .def("integrate", &FunctionTree<D>::integrate)
+        .def("quadrature",
+             [](FunctionTree<D> *tree) {
+
+                // Current implementation only makes sense in 1D
+
+                std::vector<double> vec_pts;
+                // Iterate over all end nodes
+                for (int i = 0; i < tree->getNEndNodes(); i++) {
+                    MWNode<D> &node = tree->getEndMWNode(i);
+
+                    Eigen::MatrixXd pts;
+                    node.getPrimitiveQuadPts(pts);
+
+                    // Flatten the MatrixXd and add the points from this node to the vector
+                    vec_pts.insert(vec_pts.end(), pts.data(), pts.data() + pts.size());
+                }
+
+                // Now we need to create an Eigen vector from our std::vector
+                Eigen::VectorXd final_pts = Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(vec_pts.data(), vec_pts.size());
+
+                // Now final_pts holds all the points from all nodes
+                return final_pts;
+             })
         .def(
             "normalize",
             [](FunctionTree<D> *out) {
@@ -263,6 +287,12 @@ template <int D> void trees(pybind11::module &m) {
         .def("isGenNode", &MWNode<D>::isGenNode)
         .def("hasParent", &MWNode<D>::hasParent)
         .def("hasCoefs", &MWNode<D>::hasCoefs)
+        .def("quadrature",
+            [](MWNode<D> &node) {
+                Eigen::MatrixXd pts;
+                node.getPrimitiveQuadPts(pts);
+                return pts;
+            })
         .def("center", &MWNode<D>::getCenter)
         .def("upperBounds", &MWNode<D>::getUpperBounds)
         .def("lowerBounds", &MWNode<D>::getLowerBounds)


### PR DESCRIPTION
Add quadrature method to MWNode and FunctionTree

 I'm a bit / very confused by the include:
 ```
#include <pybind11/Eigen.h>
```

Since according to @robertodr the include should be:
```
#include pybind11/eigen/matrix.h
```
see, 
https://github.com/pybind/pybind11/blob/v2.10.4/include/pybind11/eigen/matrix.h


But that does not work for me while the former does.



The method on FunctionTree, does work, but I'm not sure if it makes sense in dimensions other than 1D. However, I'm not sure what we want it to return in 2 and 3 D. 