### PR TITLE
Update pybind so it works with newer python versions

### DIFF
--- a/cmake/custom/fetch_pybind11.cmake
+++ b/cmake/custom/fetch_pybind11.cmake
@@ -1,4 +1,4 @@
-find_package(pybind11 2.6 CONFIG QUIET)
+find_package(pybind11 2.9 CONFIG QUIET)
 
 set(PYBIND11_CPP_STANDARD "-std=c++${CMAKE_CXX_STANDARD}")
 
@@ -10,9 +10,8 @@ else()
   FetchContent_Declare(pybind11
     QUIET
     URL
-      https://github.com/pybind/pybind11/archive/v2.7.1.tar.gz
+      https://github.com/pybind/pybind11/archive/v2.10.0.tar.gz
     )
   set(PYBIND11_TEST OFF CACHE BOOL "")
   FetchContent_MakeAvailable(pybind11)
 endif()
-


### PR DESCRIPTION
I got some issues when I installed vampyr using python 3.11 since the pybind11 version didn't support it. 

The code as it stands now appear to work, but I don't know if this is how it should be updated.
