### PR TITLE
Refactor derivative operator creation with factory function

### DIFF
--- a/src/vampyr/operators/derivatives.h
+++ b/src/vampyr/operators/derivatives.h
@@ -55,7 +55,7 @@ template <int D> void derivatives(pybind11::module &m) {
 
 
     // Factory function to create derivative operators based on type
-    m.def("Derivative", [](const MultiResolutionAnalysis<D> &mra, const std::string &type, int order = 1) -> std::unique_ptr<DerivativeOperator<D>> {
+    m.def("Derivative", [](const MultiResolutionAnalysis<D> &mra, const std::string &type = "center", int order = 1) -> std::unique_ptr<DerivativeOperator<D>> {
         if (type == "center") {
             return std::make_unique<ABGVOperator<D>>(mra, 0.5, 0.5);
         } else if (type == "simple") {

--- a/src/vampyr/operators/derivatives.h
+++ b/src/vampyr/operators/derivatives.h
@@ -52,5 +52,26 @@ template <int D> void derivatives(pybind11::module &m) {
     )mydelimiter")
         // clang-format on
         .def(py::init<const MultiResolutionAnalysis<D> &, int>(), "mra"_a, "order"_a = 1);
+
+
+    // Factory function to create derivative operators based on type
+    m.def("Derivative", [](const MultiResolutionAnalysis<D> &mra, const std::string &type, int order = 1) -> std::unique_ptr<DerivativeOperator<D>> {
+        if (type == "center") {
+            return std::make_unique<ABGVOperator<D>>(mra, 0.5, 0.5);
+        } else if (type == "simple") {
+            return std::make_unique<ABGVOperator<D>>(mra, 0.0, 0.0);
+        } else if (type == "forward") {
+            return std::make_unique<ABGVOperator<D>>(mra, 0.0, 1.0);
+        } else if (type == "backward") {
+            return std::make_unique<ABGVOperator<D>>(mra, 1.0, 0.0);
+        } else if (type == "b-spline") {
+            return std::make_unique<BSOperator<D>>(mra, order);
+        } else if (type == "ph") {
+            return std::make_unique<PHOperator<D>>(mra, order);
+        } else {
+            throw std::invalid_argument("Unknown derivative type: " + type);
+        }
+    }, "mra"_a, "type"_a, "order"_a = 1);
+
 }
 } // namespace vampyr


### PR DESCRIPTION
## Refactor Derivative Operator Creation

This pull request introduces a significant refactor to the way derivative operators are created within the `vampyr` Python interface. A new factory function named `Derivative` has been added to simplify the creation process and provide a more intuitive interface for users.

### Usage Instructions:

To create a derivative operator, you can now use the `Derivative` function with the desired type as a string argument. Here are the possible types and their corresponding operator configurations:

- `"center"`: Creates an ABGVOperator with parameters (0.5, 0.5)
- `"simple"`: Creates an ABGVOperator with parameters (0.0, 0.0)
- `"forward"`: Creates an ABGVOperator with parameters (0.0, 1.0)
- `"backward"`: Creates an ABGVOperator with parameters (1.0, 0.0)
- `"b-spline"`: Creates a BSOperator with a specified order (default is 1)
- `"ph"`: Creates a PHOperator with a specified order (default is 1)

Here's an example of how to use the new interface:

```python
# Assuming `mra` is an instance of MultiResolutionAnalysis<D>
D_abgv_center = vampyr.Derivative(mra, type="center")
D_abgv_simple = vampyr.Derivative(mra, type="simple")
D_abgv_forward = vampyr.Derivative(mra, type="forward")
D_abgv_backward = vampyr.Derivative(mra, type="backward")
D_b_spline = vampyr.Derivative(mra, type="b-spline", order=2)
D_ph = vampyr.Derivative(mra, type="ph", order=2)
```