### PR TITLE
Make vampyr work with mrcpp v2

### DIFF
--- a/cmake/custom/fetch_mrcpp.cmake
+++ b/cmake/custom/fetch_mrcpp.cmake
@@ -18,7 +18,7 @@ else()
     GIT_REPOSITORY
       https://github.com/MRChemSoft/mrcpp.git
     GIT_TAG
-      e2a8eea2b4c3470aaef16e4156feaa1b0570b5d8
+      cec3cc96d578cdf77e8e9222cb641ab3e9ff7236
     )
 
   set(CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER})

--- a/src/vampyr/core/bases.h
+++ b/src/vampyr/core/bases.h
@@ -23,11 +23,11 @@ void bases(pybind11::module &m) {
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    py::class_<Polynomial, PyRepresentableFunction<1, Polynomial>, RepresentableFunction<1>>(m, "Polynomial");
+    py::class_<Polynomial, PyRepresentableFunction<1, Polynomial>, RepresentableFunction<1, double>>(m, "Polynomial");
 
     py::class_<PyScalingFunction, Polynomial>(m, "ScalingFunction");
 
-    py::class_<PyWaveletFunction, RepresentableFunction<1>>(m, "WaveletFunction");
+    py::class_<PyWaveletFunction, RepresentableFunction<1, double>>(m, "WaveletFunction");
 
     py::class_<ScalingBasis>(m,
                              "ScalingBasis",

--- a/src/vampyr/export_vampyr.cpp
+++ b/src/vampyr/export_vampyr.cpp
@@ -56,16 +56,16 @@ template <int D> void bind_vampyr(py::module &mod) noexcept {
     std::string name = "vampyr" + std::to_string(D) + "d";
     py::module sub_mod = mod.def_submodule(name.c_str());
 
+    functions<D>(sub_mod);
+    trees<D>(sub_mod);
+    world<D>(sub_mod);
+    grids<D>(sub_mod);
     applys<D>(sub_mod);
     arithmetics<D>(sub_mod);
     project<D>(sub_mod);
     map<D>(sub_mod);
-
-    functions<D>(sub_mod);
     derivatives<D>(sub_mod);
     convolutions<D>(sub_mod);
-    trees<D>(sub_mod);
-    world<D>(sub_mod);
 
     bind_advanced<D>(sub_mod);
 }

--- a/src/vampyr/functions/PyRepresentableFunction.h
+++ b/src/vampyr/functions/PyRepresentableFunction.h
@@ -12,7 +12,7 @@
 
 namespace vampyr {
 
-template <int D, typename FunctionBase = mrcpp::RepresentableFunction<D>>
+template <int D, typename FunctionBase = mrcpp::RepresentableFunction<D, double>>
 class PyRepresentableFunction : public FunctionBase {
 public:
     /* Inherit the constructors */

--- a/src/vampyr/functions/functions.h
+++ b/src/vampyr/functions/functions.h
@@ -12,13 +12,13 @@ template <int D> void functions(pybind11::module &m) {
     using namespace pybind11::literals;
 
     // RepresentableFunction class
-    py::class_<RepresentableFunction<D>, PyRepresentableFunction<D>>(m,
+    py::class_<RepresentableFunction<D, double>, PyRepresentableFunction<D>>(m,
                                                                      "RepresentableFunction",
                                                                      R"mydelimiter(
        Filler text
     )mydelimiter")
         .def(py::init<const std::vector<double> &, const std::vector<double> &>())
-        .def("__call__", [](const RepresentableFunction<D> &func, const Coord<D> &r) { return func.evalf(r); });
+        .def("__call__", [](const RepresentableFunction<D, double> &func, const Coord<D> &r) { return func.evalf(r); });
 
     gaussians<D>(m);
 }

--- a/src/vampyr/functions/gaussians.h
+++ b/src/vampyr/functions/gaussians.h
@@ -15,7 +15,7 @@ template <int D> void gaussians(pybind11::module &m) {
     using namespace pybind11::literals;
 
     // Gaussian class
-    py::class_<Gaussian<D>, PyGaussian<D>, RepresentableFunction<D>>(m,
+    py::class_<Gaussian<D>, PyGaussian<D>, RepresentableFunction<D, double>>(m,
                                                                      "Gaussian",
                                                                      R"mydelimiter(
         Parent class to the GaussFunc class.
@@ -82,7 +82,7 @@ template <int D> void gaussians(pybind11::module &m) {
              Warning: power has to be a zero vector)mydelimiter");
 
     // GaussExp class
-    py::class_<GaussExp<D>, RepresentableFunction<D>>(m, "GaussExp")
+    py::class_<GaussExp<D>, RepresentableFunction<D, double>>(m, "GaussExp")
         .def(py::init())
         .def("size", py::overload_cast<>(&GaussExp<D>::size, py::const_), "Number of Gaussians in the GaussExp")
         .def("func",

--- a/src/vampyr/operators/convolutions.h
+++ b/src/vampyr/operators/convolutions.h
@@ -28,9 +28,9 @@ template <int D> void convolutions(pybind11::module &m) {
         .def(py::init<const MultiResolutionAnalysis<D> &, GaussExp<1> &, double, int, int>())
         .def(
             "__call__",
-            [](ConvolutionOperator<D> &C, FunctionTree<D> *inp) {
-                auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
-                apply<D>(C.getBuildPrec(), *out, C, *inp);
+            [](ConvolutionOperator<D> &C, FunctionTree<D, double> *inp) {
+                auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
+                apply<D, double>(C.getBuildPrec(), *out, C, *inp);
                 return out;
             },
             "inp"_a);
@@ -44,9 +44,9 @@ template <int D> void convolutions(pybind11::module &m) {
              "reach"_a = 1)
         .def(
             "__call__",
-            [](IdentityConvolution<D> &I, FunctionTree<D> *inp) {
-                auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
-                apply<D>(I.getBuildPrec(), *out, I, *inp);
+            [](IdentityConvolution<D> &I, FunctionTree<D, double> *inp) {
+                auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
+                apply<D, double>(I.getBuildPrec(), *out, I, *inp);
                 return out;
             },
             "inp"_a);
@@ -67,9 +67,9 @@ void cartesian_convolution(pybind11::module &m) {
         .def(py::init<const MultiResolutionAnalysis<3> &, GaussExp<1> &, double>(), "mra"_a, "kernel"_a, "prec"_a)
         .def(
             "__call__",
-            [](CartesianConvolution &O, FunctionTree<3> *inp) {
-                auto out = std::make_unique<FunctionTree<3>>(inp->getMRA());
-                apply<3>(O.getBuildPrec(), *out, O, *inp);
+            [](CartesianConvolution &O, FunctionTree<3, double> *inp) {
+                auto out = std::make_unique<FunctionTree<3, double>>(inp->getMRA());
+                apply<3, double>(O.getBuildPrec(), *out, O, *inp);
                 return out;
             },
             "inp"_a)
@@ -90,9 +90,9 @@ void poisson_operator(pybind11::module &m) {
              "reach"_a = 1)
         .def(
             "__call__",
-            [](PoissonOperator &P, FunctionTree<3> *inp) {
-                auto out = std::make_unique<FunctionTree<3>>(inp->getMRA());
-                apply<3>(P.getBuildPrec(), *out, P, *inp);
+            [](PoissonOperator &P, FunctionTree<3, double> *inp) {
+                auto out = std::make_unique<FunctionTree<3, double>>(inp->getMRA());
+                apply<3, double>(P.getBuildPrec(), *out, P, *inp);
                 out->rescale(1.0 / (4.0 * mrcpp::pi));
                 return out;
             },
@@ -114,9 +114,9 @@ void helmholtz_operator(pybind11::module &m) {
              "reach"_a = 1)
         .def(
             "__call__",
-            [](HelmholtzOperator &H, FunctionTree<3> *inp) {
-                auto out = std::make_unique<FunctionTree<3>>(inp->getMRA());
-                apply<3>(H.getBuildPrec(), *out, H, *inp);
+            [](HelmholtzOperator &H, FunctionTree<3, double> *inp) {
+                auto out = std::make_unique<FunctionTree<3, double>>(inp->getMRA());
+                apply<3, double>(H.getBuildPrec(), *out, H, *inp);
                 out->rescale(1.0 / (4.0 * mrcpp::pi));
                 return out;
             },
@@ -146,9 +146,9 @@ void time_evolution_operator(pybind11::module &m)
              "max_Jpower"_a = 40)
         .def(
             "__call__",
-            [](TimeEvolutionOperator<1> &T, FunctionTree<1> *inp) {
-                auto out = std::make_unique<FunctionTree<1>>(inp->getMRA());
-                apply<1>(T.getBuildPrec(), *out, T, *inp);
+            [](TimeEvolutionOperator<1> &T, FunctionTree<1, double> *inp) {
+                auto out = std::make_unique<FunctionTree<1, double>>(inp->getMRA());
+                apply<1, double>(T.getBuildPrec(), *out, T, *inp);
                 return out;
             },
             "inp"_a);
@@ -168,9 +168,9 @@ void heat_operator(pybind11::module &m)
              "prec"_a)
         .def(
             "__call__",
-            [](HeatOperator<1> &T, FunctionTree<1> *inp) {
-                auto out = std::make_unique<FunctionTree<1>>(inp->getMRA());
-                apply<1>(T.getBuildPrec(), *out, T, *inp);
+            [](HeatOperator<1> &T, FunctionTree<1, double> *inp) {
+                auto out = std::make_unique<FunctionTree<1, double>>(inp->getMRA());
+                apply<1, double>(T.getBuildPrec(), *out, T, *inp);
                 return out;
             },
             "inp"_a);

--- a/src/vampyr/operators/derivatives.h
+++ b/src/vampyr/operators/derivatives.h
@@ -24,8 +24,8 @@ template <int D> void derivatives(pybind11::module &m) {
         .def("getOrder", &DerivativeOperator<D>::getOrder)
         .def(
             "__call__",
-            [](DerivativeOperator<D> &oper, FunctionTree<D> *inp, int axis) {
-                auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
+            [](DerivativeOperator<D> &oper, FunctionTree<D, double> *inp, int axis) {
+                auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
                 apply(*out, oper, *inp, axis);
                 return out;
             },

--- a/src/vampyr/tests/test_basis.py
+++ b/src/vampyr/tests/test_basis.py
@@ -30,7 +30,7 @@ def test_InterpolatingScalingBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
 
 
 def test_InterpolatingWaveletBasis():
@@ -39,7 +39,7 @@ def test_InterpolatingWaveletBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
 
 
 def test_LegendreScalingBasis():
@@ -48,7 +48,7 @@ def test_LegendreScalingBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
 
 
 def test_LegendreWaveletBasis():
@@ -57,4 +57,4 @@ def test_LegendreWaveletBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)

--- a/src/vampyr/tests/test_basis.py
+++ b/src/vampyr/tests/test_basis.py
@@ -3,6 +3,11 @@ import pytest
 
 import vampyr as vp
 
+try:
+    trapezoid = np.trapezoid  
+except AttributeError:
+    trapezoid = np.trapz     
+
 
 def test_LegendreBasis():
     basis = vp.LegendreBasis(order=5)

--- a/src/vampyr/tests/test_basis.py
+++ b/src/vampyr/tests/test_basis.py
@@ -30,7 +30,7 @@ def test_InterpolatingScalingBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
 
 
 def test_InterpolatingWaveletBasis():
@@ -39,7 +39,7 @@ def test_InterpolatingWaveletBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
 
 
 def test_LegendreScalingBasis():
@@ -48,7 +48,7 @@ def test_LegendreScalingBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)
 
 
 def test_LegendreWaveletBasis():
@@ -57,4 +57,4 @@ def test_LegendreWaveletBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(np.trapz(f_squared, dx=dx), 0.001)

--- a/src/vampyr/tests/test_basis.py
+++ b/src/vampyr/tests/test_basis.py
@@ -35,7 +35,7 @@ def test_InterpolatingScalingBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(trapezoid(f_squared, dx=dx), 0.001)
 
 
 def test_InterpolatingWaveletBasis():
@@ -44,7 +44,7 @@ def test_InterpolatingWaveletBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(trapezoid(f_squared, dx=dx), 0.001)
 
 
 def test_LegendreScalingBasis():
@@ -53,7 +53,7 @@ def test_LegendreScalingBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(trapezoid(f_squared, dx=dx), 0.001)
 
 
 def test_LegendreWaveletBasis():
@@ -62,4 +62,4 @@ def test_LegendreWaveletBasis():
     dx = 0.0001
     x = np.arange(0, 0.51, dx)
     f_squared = [f([x]) * f([x]) for x in x]
-    assert 1.0 == pytest.approx(np.trapezoid(f_squared, dx=dx), 0.001)
+    assert 1.0 == pytest.approx(trapezoid(f_squared, dx=dx), 0.001)

--- a/src/vampyr/treebuilders/PyFunctionMap.h
+++ b/src/vampyr/treebuilders/PyFunctionMap.h
@@ -12,10 +12,10 @@ public:
             : precision(prec)
             , func_map(fmap) {}
 
-    std::unique_ptr<FunctionTree<D>> operator()(FunctionTree<D> &inp) {
+    std::unique_ptr<FunctionTree<D, double>> operator()(FunctionTree<D, double> &inp) {
         // Negative precision will copy grid from input
-        auto out = std::make_unique<FunctionTree<D>>(inp.getMRA());
-        if (this->precision < 0.0) copy_grid<D>(*out, inp);
+        auto out = std::make_unique<FunctionTree<D, double>>(inp.getMRA());
+        if (this->precision < 0.0) copy_grid<D, double>(*out, inp);
         map<D>(this->precision, *out, inp, this->func_map);
         return out;
     }

--- a/src/vampyr/treebuilders/PyProjectors.h
+++ b/src/vampyr/treebuilders/PyProjectors.h
@@ -18,17 +18,17 @@ public:
         if (this->min_scale < this->MRA.getRootScale()) MSG_ERROR("Invalid scale");
     }
 
-    std::unique_ptr<FunctionTree<D>> operator()(RepresentableFunction<D> &func) {
-        auto out = std::make_unique<FunctionTree<D>>(this->MRA);
+    std::unique_ptr<FunctionTree<D, double>> operator()(RepresentableFunction<D, double> &func) {
+        auto out = std::make_unique<FunctionTree<D, double>>(this->MRA);
         if (this->precision > 0.0) {
             // With the adaptive projection we want s+w repr at finest scale
-            build_grid<D>(*out, func);
-            project<D>(this->precision, *out, func);
+            build_grid<D, double>(*out, func);
+            project<D, double>(this->precision, *out, func);
         } else {
             // With the fixed scale projection we want pure s repr at finest scale
             int depth = this->min_scale - this->MRA.getRootScale();
-            build_grid<D>(*out, depth);
-            project<D>(-1.0, *out, func);
+            build_grid<D, double>(*out, depth);
+            project<D, double>(-1.0, *out, func);
 
             // Need to explicitly clear w coefs after projection to get only s coefs
             for (int n = 0; n < out->getNEndNodes(); n++) {
@@ -42,15 +42,15 @@ public:
         return out;
     }
 
-    std::unique_ptr<FunctionTree<D>> operator()(std::function<double(const Coord<D> &r)> func) {
-        auto out = std::make_unique<FunctionTree<D>>(this->MRA);
+    std::unique_ptr<FunctionTree<D, double>> operator()(std::function<double(const Coord<D> &r)> func) {
+        auto out = std::make_unique<FunctionTree<D, double>>(this->MRA);
         if (this->precision > 0.0) {
             // With the adaptive projection we want s+w repr at finest scale
             project<D>(this->precision, *out, func);
         } else {
             // With the fixed scale projection we want pure s repr at finest scale
             int depth = this->min_scale - this->MRA.getRootScale();
-            build_grid<D>(*out, depth);
+            build_grid<D, double>(*out, depth);
             project<D>(-1.0, *out, func);
 
             // Need to explicitly clear w coefs after projection to get only s coefs
@@ -79,14 +79,14 @@ public:
         if (this->min_scale < this->MRA.getRootScale()) MSG_ERROR("Invalid scale");
     }
 
-    std::unique_ptr<FunctionTree<D>> operator()(RepresentableFunction<D> &func) {
+    std::unique_ptr<FunctionTree<D, double>> operator()(RepresentableFunction<D, double> &func) {
         // With the fixed scale projection we want pure w repr at finest scale
-        auto out = std::make_unique<FunctionTree<D>>(this->MRA);
+        auto out = std::make_unique<FunctionTree<D, double>>(this->MRA);
 
         // Project uniformly at scale n
         int depth = this->min_scale - this->MRA.getRootScale();
-        build_grid<D>(*out, depth);
-        project<D>(-1.0, *out, func);
+        build_grid<D, double>(*out, depth);
+        project<D, double>(-1.0, *out, func);
 
         // Need to explicitly clear s coefs after projection to get only w coefs
         for (int n = 0; n < out->getNEndNodes(); n++) {
@@ -99,13 +99,13 @@ public:
         return out;
     }
 
-    std::unique_ptr<FunctionTree<D>> operator()(std::function<double(const Coord<D> &r)> func) {
+    std::unique_ptr<FunctionTree<D, double>> operator()(std::function<double(const Coord<D> &r)> func) {
         // With the fixed scale projection we want pure w repr at finest scale
-        auto out = std::make_unique<FunctionTree<D>>(this->MRA);
+        auto out = std::make_unique<FunctionTree<D, double>>(this->MRA);
 
         // Project uniformly at scale n
         int depth = this->min_scale - this->MRA.getRootScale();
-        build_grid<D>(*out, depth);
+        build_grid<D, double>(*out, depth);
         project<D>(-1.0, *out, func);
 
         // Need to explicitly clear s coefs after projection to get only w coefs

--- a/src/vampyr/treebuilders/grids.h
+++ b/src/vampyr/treebuilders/grids.h
@@ -1,57 +1,117 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <MRCPP/treebuilders/grid.h>
 
 namespace vampyr {
+
+template <int D> void grids(pybind11::module &m) {
+    using namespace mrcpp;
+    namespace py = pybind11;
+    using namespace pybind11::literals;
+
+    m.def(
+        "build_grid",
+        [](FunctionTree<D, double> &out, int scales) { build_grid<D, double>(out, scales); },
+        "out"_a,
+        "scales"_a);
+
+    m.def(
+        "build_grid",
+        [](FunctionTree<D, double> &out, FunctionTree<D, double> &inp, int max_iter) {
+            build_grid<D, double>(out, inp, max_iter);
+        },
+        "out"_a,
+        "inp"_a,
+        "max_iter"_a = -1);
+}
+
 template <int D> void advanced_grids(pybind11::module &m) {
     using namespace mrcpp;
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    m.def("build_grid", py::overload_cast<FunctionTree<D> &, int>(&build_grid<D>), "out"_a, "scales"_a);
-
-    m.def("build_grid",
-          py::overload_cast<FunctionTree<D> &, FunctionTree<D> &, int>(&build_grid<D>),
-          "out"_a,
-          "inp"_a,
-          "max_iter"_a = -1);
-
-    m.def("build_grid",
-          py::overload_cast<FunctionTree<D> &, const RepresentableFunction<D> &, int>(&build_grid<D>),
-          "out"_a,
-          "inp"_a,
-          "max_iter"_a = -1);
-
-    m.def("build_grid",
-          py::overload_cast<FunctionTree<D> &, std::vector<FunctionTree<D> *> &, int>(&build_grid<D>),
-          "out"_a,
-          "inp"_a,
-          "max_iter"_a = -1);
+    m.def(
+        "build_grid",
+        [](FunctionTree<D, double> &out, int scales) { build_grid<D, double>(out, scales); },
+        "out"_a,
+        "scales"_a);
 
     m.def(
         "build_grid",
-        py::overload_cast<FunctionTree<D> &, std::vector<std::tuple<double, FunctionTree<D> *>> &, int>(&build_grid<D>),
+        [](FunctionTree<D, double> &out, FunctionTree<D, double> &inp, int max_iter) {
+            build_grid<D, double>(out, inp, max_iter);
+        },
         "out"_a,
         "inp"_a,
         "max_iter"_a = -1);
 
-    m.def("copy_grid", py::overload_cast<FunctionTree<D> &, FunctionTree<D> &>(&copy_grid<D>), "out"_a, "inp"_a);
+    m.def(
+        "build_grid",
+        [](FunctionTree<D, double> &out, const RepresentableFunction<D, double> &inp, int max_iter) {
+            build_grid<D, double>(out, inp, max_iter);
+        },
+        "out"_a,
+        "inp"_a,
+        "max_iter"_a = -1);
 
-    m.def("copy_func", py::overload_cast<FunctionTree<D> &, FunctionTree<D> &>(&copy_func<D>), "out"_a, "inp"_a);
+    m.def(
+        "build_grid",
+        [](FunctionTree<D, double> &out, std::vector<FunctionTree<D, double> *> &inp, int max_iter) {
+            FunctionTreeVector<D, double> vec;
+            for (auto *tree : inp) vec.push_back({1.0, tree});
+            build_grid<D, double>(out, vec, max_iter);
+        },
+        "out"_a,
+        "inp"_a,
+        "max_iter"_a = -1);
 
-    m.def("clear_grid", py::overload_cast<FunctionTree<D> &>(&clear_grid<D>), "out"_a);
+    m.def(
+        "build_grid",
+        [](FunctionTree<D, double> &out, std::vector<std::tuple<double, FunctionTree<D, double> *>> &inp, int max_iter) {
+            FunctionTreeVector<D, double> vec;
+            for (auto &t : inp) vec.push_back({std::get<0>(t), std::get<1>(t)});
+            build_grid<D, double>(out, vec, max_iter);
+        },
+        "out"_a,
+        "inp"_a,
+        "max_iter"_a = -1);
 
-    m.def("refine_grid", py::overload_cast<FunctionTree<D> &, int>(&refine_grid<D>), "out"_a, "scales"_a);
+    m.def(
+        "copy_grid",
+        [](FunctionTree<D, double> &out, FunctionTree<D, double> &inp) { copy_grid<D, double>(out, inp); },
+        "out"_a,
+        "inp"_a);
 
-    m.def("refine_grid",
-          py::overload_cast<FunctionTree<D> &, double, bool>(&refine_grid<D>),
-          "out"_a,
-          "prec"_a,
-          "abs_prec"_a = false);
+    m.def(
+        "copy_func",
+        [](FunctionTree<D, double> &out, FunctionTree<D, double> &inp) { copy_func<D, double>(out, inp); },
+        "out"_a,
+        "inp"_a);
 
-    m.def("refine_grid", py::overload_cast<FunctionTree<D> &, FunctionTree<D> &>(&refine_grid<D>), "out"_a, "inp"_a);
+    m.def(
+        "clear_grid", [](FunctionTree<D, double> &out) { clear_grid<D, double>(out); }, "out"_a);
+
+    m.def(
+        "refine_grid",
+        [](FunctionTree<D, double> &out, int scales) { return refine_grid<D, double>(out, scales); },
+        "out"_a,
+        "scales"_a);
+
+    m.def(
+        "refine_grid",
+        [](FunctionTree<D, double> &out, double prec, bool abs_prec) { return refine_grid<D, double>(out, prec, abs_prec); },
+        "out"_a,
+        "prec"_a,
+        "abs_prec"_a = false);
+
+    m.def(
+        "refine_grid",
+        [](FunctionTree<D, double> &out, FunctionTree<D, double> &inp) { return refine_grid<D, double>(out, inp); },
+        "out"_a,
+        "inp"_a);
 }
 
 } // namespace vampyr

--- a/src/vampyr/treebuilders/maps.h
+++ b/src/vampyr/treebuilders/maps.h
@@ -3,6 +3,7 @@
 #include <pybind11/functional.h>
 
 #include "PyFunctionMap.h"
+#include <MRCPP/treebuilders/map.h>
 
 namespace vampyr {
 template <int D> void map(pybind11::module &m) {
@@ -14,7 +15,7 @@ template <int D> void map(pybind11::module &m) {
         .def(py::init<std::function<double(double)>, double>(), "fmap"_a, "prec"_a)
         .def(
             "__call__",
-            [](PyFunctionMap<D> &F, FunctionTree<D> &inp) {
+            [](PyFunctionMap<D> &F, FunctionTree<D, double> &inp) {
                 auto old_threads = mrcpp_get_num_threads();
                 set_max_threads(1);
                 auto out = F(inp);
@@ -32,8 +33,8 @@ template <int D> void advanced_map(pybind11::module &m) {
     m.def(
         "map",
         [](double prec,
-           FunctionTree<D> &out,
-           FunctionTree<D> &inp,
+           FunctionTree<D, double> &out,
+           FunctionTree<D, double> &inp,
            std::function<double(double)> fmap,
            int max_iter,
            bool abs_prec) {

--- a/src/vampyr/treebuilders/project.h
+++ b/src/vampyr/treebuilders/project.h
@@ -13,7 +13,7 @@ template <int D> void project(pybind11::module &m) {
     m.def(
         "ZeroTree",
         [](const MultiResolutionAnalysis<D> &mra, const std::string &name) {
-            auto out = std::make_unique<FunctionTree<D>>(mra, name);
+            auto out = std::make_unique<FunctionTree<D, double>>(mra, name);
             out->setZero();
             return out;
         },
@@ -24,7 +24,7 @@ template <int D> void project(pybind11::module &m) {
         .def(py::init<const MultiResolutionAnalysis<D> &, double>(), "mra"_a, "prec"_a)
         .def(py::init<const MultiResolutionAnalysis<D> &, int>(), "mra"_a, "scale"_a)
         .def(
-            "__call__", [](PyScalingProjector<D> &P, RepresentableFunction<D> &func) { return P(func); }, "func"_a)
+            "__call__", [](PyScalingProjector<D> &P, RepresentableFunction<D, double> &func) { return P(func); }, "func"_a)
         .def(
             "__call__",
             [](PyScalingProjector<D> &P, std::function<double(const Coord<D> &r)> func) {
@@ -50,7 +50,7 @@ template <int D> void project(pybind11::module &m) {
     py::class_<PyWaveletProjector<D>>(m, "WaveletProjector")
         .def(py::init<const MultiResolutionAnalysis<D> &, int>(), "mra"_a, "scale"_a)
         .def(
-            "__call__", [](PyWaveletProjector<D> &P, RepresentableFunction<D> &func) { return P(func); }, "func"_a)
+            "__call__", [](PyWaveletProjector<D> &P, RepresentableFunction<D, double> &func) { return P(func); }, "func"_a)
         .def(
             "__call__",
             [](PyWaveletProjector<D> &P, std::function<double(const Coord<D> &r)> func) {
@@ -78,7 +78,9 @@ template <int D> void advanced_project(pybind11::module &m) {
     using namespace pybind11::literals;
 
     m.def("project",
-          py::overload_cast<double, FunctionTree<D> &, RepresentableFunction<D> &, int, bool>(&mrcpp::project<D>),
+          [](double prec, FunctionTree<D, double> &out, RepresentableFunction<D, double> &inp, int max_iter, bool abs_prec) {
+              mrcpp::project<D, double>(prec, out, inp, max_iter, abs_prec);
+          },
           "prec"_a = -1.0,
           "out"_a,
           "inp"_a,
@@ -88,7 +90,7 @@ template <int D> void advanced_project(pybind11::module &m) {
     m.def(
         "project",
         [](double prec,
-           FunctionTree<D> &out,
+           FunctionTree<D, double> &out,
            std::function<double(const Coord<D> &r)> inp,
            int max_iter,
            bool abs_prec) {

--- a/src/vampyr/trees/trees.h
+++ b/src/vampyr/trees/trees.h
@@ -13,11 +13,11 @@
 
 namespace vampyr {
 template <int D>
-auto impl__add__(mrcpp::FunctionTree<D> *inp_a, mrcpp::FunctionTree<D> *inp_b)
-    -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+auto impl__add__(mrcpp::FunctionTree<D, double> *inp_a, mrcpp::FunctionTree<D, double> *inp_b)
+    -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp_a->getMRA());
-    FunctionTreeVector<D> vec;
+    auto out = std::make_unique<FunctionTree<D, double>>(inp_a->getMRA());
+    FunctionTreeVector<D, double> vec;
     vec.push_back({1.0, inp_a});
     vec.push_back({1.0, inp_b});
     build_grid(*out, vec);
@@ -26,11 +26,11 @@ auto impl__add__(mrcpp::FunctionTree<D> *inp_a, mrcpp::FunctionTree<D> *inp_b)
 };
 
 template <int D>
-auto impl__sub__(mrcpp::FunctionTree<D> *inp_a, mrcpp::FunctionTree<D> *inp_b)
-    -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+auto impl__sub__(mrcpp::FunctionTree<D, double> *inp_a, mrcpp::FunctionTree<D, double> *inp_b)
+    -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp_a->getMRA());
-    FunctionTreeVector<D> vec;
+    auto out = std::make_unique<FunctionTree<D, double>>(inp_a->getMRA());
+    FunctionTreeVector<D, double> vec;
     vec.push_back({1.0, inp_a});
     vec.push_back({-1.0, inp_b});
     build_grid(*out, vec);
@@ -39,11 +39,11 @@ auto impl__sub__(mrcpp::FunctionTree<D> *inp_a, mrcpp::FunctionTree<D> *inp_b)
 };
 
 template <int D>
-auto impl__mul__(mrcpp::FunctionTree<D> *inp_a, mrcpp::FunctionTree<D> *inp_b)
-    -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+auto impl__mul__(mrcpp::FunctionTree<D, double> *inp_a, mrcpp::FunctionTree<D, double> *inp_b)
+    -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp_a->getMRA());
-    FunctionTreeVector<D> vec;
+    auto out = std::make_unique<FunctionTree<D, double>>(inp_a->getMRA());
+    FunctionTreeVector<D, double> vec;
     vec.push_back({1.0, inp_a});
     vec.push_back({1.0, inp_b});
     build_grid(*out, vec);
@@ -52,28 +52,29 @@ auto impl__mul__(mrcpp::FunctionTree<D> *inp_a, mrcpp::FunctionTree<D> *inp_b)
     return out;
 };
 
-template <int D> auto impl__mul__(mrcpp::FunctionTree<D> *inp_a, double c) -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+template <int D>
+auto impl__mul__(mrcpp::FunctionTree<D, double> *inp_a, double c) -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp_a->getMRA());
-    FunctionTreeVector<D> vec;
+    auto out = std::make_unique<FunctionTree<D, double>>(inp_a->getMRA());
+    FunctionTreeVector<D, double> vec;
     vec.push_back({c, inp_a});
     build_grid(*out, vec);
     add(-1.0, *out, vec);
     return out;
 };
 
-template <int D> auto impl__pos__(mrcpp::FunctionTree<D> *inp) -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+template <int D> auto impl__pos__(mrcpp::FunctionTree<D, double> *inp) -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
+    auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
     copy_grid(*out, *inp);
     copy_func(*out, *inp);
     return out;
 };
 
-template <int D> auto impl__neg__(mrcpp::FunctionTree<D> *inp) -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+template <int D> auto impl__neg__(mrcpp::FunctionTree<D, double> *inp) -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
-    FunctionTreeVector<D> vec;
+    auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
+    FunctionTreeVector<D, double> vec;
     vec.push_back({-1.0, inp});
     build_grid(*out, vec);
     add(-1.0, *out, vec);
@@ -81,19 +82,19 @@ template <int D> auto impl__neg__(mrcpp::FunctionTree<D> *inp) -> std::unique_pt
 };
 
 template <int D>
-auto impl__truediv__(mrcpp::FunctionTree<D> *inp, double c) -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+auto impl__truediv__(mrcpp::FunctionTree<D, double> *inp, double c) -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
-    FunctionTreeVector<D> vec;
+    auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
+    FunctionTreeVector<D, double> vec;
     vec.push_back({1.0 / c, inp});
     build_grid(*out, vec);
     add(-1.0, *out, vec);
     return out;
 };
 
-template <int D> auto impl__pow__(mrcpp::FunctionTree<D> *inp, double c) -> std::unique_ptr<mrcpp::FunctionTree<D>> {
+template <int D> auto impl__pow__(mrcpp::FunctionTree<D, double> *inp, double c) -> std::unique_ptr<mrcpp::FunctionTree<D, double>> {
     using namespace mrcpp;
-    auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
+    auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
     copy_grid(*out, *inp);
     copy_func(*out, *inp);
     refine_grid(*out, 1);
@@ -106,160 +107,129 @@ template <int D> void trees(pybind11::module &m) {
     namespace py = pybind11;
     using namespace pybind11::literals;
 
-    py::class_<MWTree<D>>(m, "MWTree")
-        .def("MRA", &MWTree<D>::getMRA, py::return_value_policy::reference_internal)
-        .def("nNodes", &MWTree<D>::getNNodes)
-        .def("nEndNodes", &MWTree<D>::getNEndNodes)
-        .def("nRootNodes", &MWTree<D>::getNRootNodes)
+    py::class_<MWTree<D, double>>(m, "MWTree")
+        .def("MRA", &MWTree<D, double>::getMRA, py::return_value_policy::reference_internal)
+        .def("nNodes", &MWTree<D, double>::getNNodes)
+        .def("nEndNodes", &MWTree<D, double>::getNEndNodes)
+        .def("nRootNodes", &MWTree<D, double>::getNRootNodes)
         .def("fetchEndNode",
-             py::overload_cast<int>(&MWTree<D>::getEndMWNode, py::const_),
+             [](MWTree<D, double>& tree, int i) -> MWNode<D, double>& { return tree.getEndMWNode(i); },
              py::return_value_policy::reference_internal)
         .def("fetchRootNode",
-             py::overload_cast<int>(&MWTree<D>::getRootMWNode, py::const_),
+             [](MWTree<D, double>& tree, int i) -> MWNode<D, double>& { return tree.getRootMWNode(i); },
              py::return_value_policy::reference_internal)
-        .def("rootScale", &MWTree<D>::getRootScale)
-        .def("depth", &MWTree<D>::getDepth)
+        .def("rootScale", &MWTree<D, double>::getRootScale)
+        .def("depth", &MWTree<D, double>::getDepth)
         .def("setZero",
-             [](MWTree<D> *out) {
+             [](MWTree<D, double> *out) {
                  out->setZero();
                  return out;
              })
-        .def("clear", &MWTree<D>::clear)
-        .def("setName", &MWTree<D>::setName)
-        .def("name", &MWTree<D>::getName)
+        .def("clear", &MWTree<D, double>::clear)
+        .def("setName", &MWTree<D, double>::setName)
+        .def("name", &MWTree<D, double>::getName)
         .def("fetchNode",
-             py::overload_cast<NodeIndex<D>>(&MWTree<D>::getNode),
+             [](MWTree<D, double>& tree, NodeIndex<D> idx) -> MWNode<D, double>& { return tree.getNode(idx); },
              py::return_value_policy::reference_internal)
-        .def("squaredNorm", &MWTree<D>::getSquareNorm)
+        .def("squaredNorm", &MWTree<D, double>::getSquareNorm)
         .def("norm",
-             [](MWTree<D> &tree) {
+             [](MWTree<D, double> &tree) {
                  auto sqNorm = tree.getSquareNorm();
                  return (sqNorm >= 0.0) ? std::sqrt(sqNorm) : -1.0;
              })
-        .def("__str__", [](MWTree<D> &tree) {
+        .def("__str__", [](MWTree<D, double> &tree) {
             std::ostringstream os;
             os << tree;
             return os.str();
         });
 
-    py::class_<FunctionTree<D>, MWTree<D>, RepresentableFunction<D>>(m, "FunctionTree")
+    py::class_<FunctionTree<D, double>, MWTree<D, double>, RepresentableFunction<D, double>>(m, "FunctionTree")
         .def(py::init<const MultiResolutionAnalysis<D> &, const std::string &>(), "mra"_a, "name"_a = "nn")
-        .def("nGenNodes", &FunctionTree<D>::getNGenNodes)
-        .def("deleteGenerated", &FunctionTree<D>::deleteGenerated)
-        .def("integrate", &FunctionTree<D>::integrate)
+        .def("nGenNodes", &FunctionTree<D, double>::getNGenNodes)
+        .def("deleteGenerated", &FunctionTree<D, double>::deleteGenerated)
+        .def("integrate", &FunctionTree<D, double>::integrate)
         .def("normalize",
-             [](FunctionTree<D> *out) {
+             [](FunctionTree<D, double> *out) {
                  out->normalize();
                  return out;
              })
         .def(
             "saveTree",
-            [](FunctionTree<D> &obj, const std::string &filename) {
+            [](FunctionTree<D, double> &obj, const std::string &filename) {
                 namespace fs = std::filesystem;
                 obj.saveTree(filename);
                 return fs::absolute(fs::path(filename + ".tree"));
             },
             "filename"_a)
-        .def("loadTree", &FunctionTree<D>::loadTree, "filename"_a)
+        .def("loadTree", &FunctionTree<D, double>::loadTree, "filename"_a)
         .def(
             "crop",
-            [](FunctionTree<D> *out, double prec, bool abs_prec) {
+            [](FunctionTree<D, double> *out, double prec, bool abs_prec) {
                 out->crop(prec, 1.0, abs_prec);
                 return out;
             },
             "prec"_a,
             "abs_prec"_a = false)
         .def("deepCopy",
-             [](FunctionTree<D> *inp) {
-                 auto out = std::make_unique<FunctionTree<D>>(inp->getMRA());
+             [](FunctionTree<D, double> *inp) {
+                 auto out = std::make_unique<FunctionTree<D, double>>(inp->getMRA());
                  copy_grid(*out, *inp);
                  copy_func(*out, *inp);
                  return out;
              })
-        .def("quadrature",
-             [](FunctionTree<D> *tree) {
-                 if constexpr (D != 1) { throw std::runtime_error("quadrature only implemented for 1D"); }
-
-                 // Current implementation only makes sense in 1D
-
-                 std::vector<double> vec_pts;
-                 // Iterate over all end nodes
-                 for (int i = 0; i < tree->getNEndNodes(); i++) {
-                     MWNode<D> &node = tree->getEndMWNode(i);
-
-                     Eigen::MatrixXd pts;
-                     node.getPrimitiveQuadPts(pts);
-
-                     // Flatten the MatrixXd and add the points from this node to the vector
-                     vec_pts.insert(vec_pts.end(), pts.data(), pts.data() + pts.size());
-                 }
-
-                 // Now we need to create an Eigen vector from our std::vector
-                 Eigen::VectorXd final_pts =
-                     Eigen::Map<Eigen::VectorXd, Eigen::Unaligned>(vec_pts.data(), vec_pts.size());
-
-                 // Now final_pts holds all the points from all nodes
-                 return final_pts;
-             })
-        .def("__call__", [](FunctionTree<D> &func, const Coord<D> &r) { return func.evalf_precise(r); })
+        .def("__call__", [](FunctionTree<D, double> &func, const Coord<D> &r) { return func.evalf_precise(r); })
         .def("__pos__", &impl__pos__<D>, py::is_operator())
         .def("__neg__", &impl__neg__<D>, py::is_operator())
         .def("__add__", &impl__add__<D>, py::is_operator())
         .def("__iadd__", &impl__add__<D>, py::is_operator())
         .def("__sub__", &impl__sub__<D>, py::is_operator())
         .def("__isub__", &impl__sub__<D>, py::is_operator())
-        .def("__mul__", py::overload_cast<FunctionTree<D> *, FunctionTree<D> *>(&impl__mul__<D>), py::is_operator())
-        .def("__mul__", py::overload_cast<FunctionTree<D> *, double>(&impl__mul__<D>), py::is_operator())
-        .def("__imul__", py::overload_cast<FunctionTree<D> *, FunctionTree<D> *>(&impl__mul__<D>), py::is_operator())
-        .def("__imul__", py::overload_cast<FunctionTree<D> *, double>(&impl__mul__<D>), py::is_operator())
-        .def("__rmul__", py::overload_cast<FunctionTree<D> *, double>(&impl__mul__<D>), py::is_operator())
+        .def("__mul__", py::overload_cast<FunctionTree<D, double> *, FunctionTree<D, double> *>(&impl__mul__<D>), py::is_operator())
+        .def("__mul__", py::overload_cast<FunctionTree<D, double> *, double>(&impl__mul__<D>), py::is_operator())
+        .def("__imul__", py::overload_cast<FunctionTree<D, double> *, FunctionTree<D, double> *>(&impl__mul__<D>), py::is_operator())
+        .def("__imul__", py::overload_cast<FunctionTree<D, double> *, double>(&impl__mul__<D>), py::is_operator())
+        .def("__rmul__", py::overload_cast<FunctionTree<D, double> *, double>(&impl__mul__<D>), py::is_operator())
         .def("__truediv__", &impl__truediv__<D>, py::is_operator())
         .def("__itruediv__", &impl__truediv__<D>, py::is_operator())
         .def("__pow__", &impl__pow__<D>, py::is_operator())
         .def("__ipow__", &impl__pow__<D>, py::is_operator());
 
-    py::class_<MWNode<D>>(m, "MWNode")
-        .def("depth", &MWNode<D>::getDepth)
-        .def("scale", &MWNode<D>::getScale)
-        .def("nCoefs", &MWNode<D>::getNCoefs)
-        .def("nChildren", &MWNode<D>::getNChildren)
+    py::class_<MWNode<D, double>>(m, "MWNode")
+        .def("depth", &MWNode<D, double>::getDepth)
+        .def("scale", &MWNode<D, double>::getScale)
+        .def("nCoefs", &MWNode<D, double>::getNCoefs)
+        .def("nChildren", &MWNode<D, double>::getNChildren)
         .def("index",
-             py::overload_cast<>(&MWNode<D>::getNodeIndex, py::const_),
+             [](MWNode<D, double>& node) -> const NodeIndex<D>& { return node.getNodeIndex(); },
              py::return_value_policy::reference_internal)
         .def("norm",
-             [](MWNode<D> &node) {
+             [](MWNode<D, double> &node) {
                  auto sqNorm = node.getSquareNorm();
                  return (sqNorm >= 0.0) ? std::sqrt(sqNorm) : -1.0;
              })
-        .def("squaredNorm", &MWNode<D>::getSquareNorm)
-        .def("scalingNorm", &MWNode<D>::getScalingNorm)
-        .def("waveletNorm", &MWNode<D>::getWaveletNorm)
-        .def("componentNorm", &MWNode<D>::getComponentNorm)
-        .def("isAllocated", &MWNode<D>::isAllocated)
-        .def("isRootNode", &MWNode<D>::isRootNode)
-        .def("isEndNode", &MWNode<D>::isEndNode)
-        .def("isLeafNode", &MWNode<D>::isLeafNode)
-        .def("isBranchNode", &MWNode<D>::isBranchNode)
-        .def("isGenNode", &MWNode<D>::isGenNode)
-        .def("hasParent", &MWNode<D>::hasParent)
-        .def("hasCoefs", &MWNode<D>::hasCoefs)
-        .def("quadrature",
-             [](MWNode<D> &node) {
-                 Eigen::MatrixXd pts;
-                 node.getPrimitiveQuadPts(pts);
-                 return pts;
-             })
-        .def("center", &MWNode<D>::getCenter)
-        .def("upperBounds", &MWNode<D>::getUpperBounds)
-        .def("lowerBounds", &MWNode<D>::getLowerBounds)
-        .def("__str__", [](MWNode<D> &node) {
+        .def("squaredNorm", &MWNode<D, double>::getSquareNorm)
+        .def("scalingNorm", &MWNode<D, double>::getScalingNorm)
+        .def("waveletNorm", &MWNode<D, double>::getWaveletNorm)
+        .def("componentNorm", &MWNode<D, double>::getComponentNorm)
+        .def("isAllocated", &MWNode<D, double>::isAllocated)
+        .def("isRootNode", &MWNode<D, double>::isRootNode)
+        .def("isEndNode", &MWNode<D, double>::isEndNode)
+        .def("isLeafNode", &MWNode<D, double>::isLeafNode)
+        .def("isBranchNode", &MWNode<D, double>::isBranchNode)
+        .def("isGenNode", &MWNode<D, double>::isGenNode)
+        .def("hasParent", &MWNode<D, double>::hasParent)
+        .def("hasCoefs", &MWNode<D, double>::hasCoefs)
+        .def("center", &MWNode<D, double>::getCenter)
+        .def("upperBounds", &MWNode<D, double>::getUpperBounds)
+        .def("lowerBounds", &MWNode<D, double>::getLowerBounds)
+        .def("__str__", [](MWNode<D, double> &node) {
             std::ostringstream os;
             os << node;
             return os.str();
         });
 
-    py::class_<FunctionNode<D>, MWNode<D>, std::unique_ptr<FunctionNode<D>, py::nodelete>>(m, "FunctionNode")
-        .def("integrate", &FunctionNode<D>::integrate);
+    py::class_<FunctionNode<D, double>, MWNode<D, double>, std::unique_ptr<FunctionNode<D, double>, py::nodelete>>(m, "FunctionNode")
+        .def("integrate", &FunctionNode<D, double>::integrate);
 
     py::class_<NodeIndex<D>>(m, "NodeIndex")
         .def(py::init<int, const std::array<int, D>>(), "scale"_a = 0, "translation"_a = std::array<int, D>{})
@@ -278,15 +248,15 @@ template <int D> void trees(pybind11::module &m) {
             return os.str();
         });
 
-    py::class_<TreeIterator<D>>(m, "TreeIterator")
+    py::class_<TreeIterator<D, double>>(m, "TreeIterator")
         .def(py::init<Traverse, Iterator>(), "traverse"_a = TopDown, "iterator"_a = Lebesgue)
-        .def(py::init<MWTree<D> &, Traverse, Iterator>(), "tree"_a, "traverse"_a = TopDown, "iterator"_a = Lebesgue)
-        .def("setReturnGenNodes", &TreeIterator<D>::setReturnGenNodes)
-        .def("setMaxDepth", &TreeIterator<D>::setMaxDepth)
-        .def("setTraverse", &TreeIterator<D>::setTraverse)
-        .def("setIterator", &TreeIterator<D>::setIterator)
-        .def("get", py::overload_cast<>(&TreeIterator<D>::getNode), py::return_value_policy::reference_internal)
-        .def("init", &TreeIterator<D>::init)
-        .def("next", &TreeIterator<D>::next);
+        .def(py::init<MWTree<D, double> &, Traverse, Iterator>(), "tree"_a, "traverse"_a = TopDown, "iterator"_a = Lebesgue)
+        .def("setReturnGenNodes", &TreeIterator<D, double>::setReturnGenNodes)
+        .def("setMaxDepth", &TreeIterator<D, double>::setMaxDepth)
+        .def("setTraverse", &TreeIterator<D, double>::setTraverse)
+        .def("setIterator", &TreeIterator<D, double>::setIterator)
+        .def("get", [](TreeIterator<D, double>& it) -> MWNode<D, double>& { return it.getNode(); }, py::return_value_policy::reference_internal)
+        .def("init", &TreeIterator<D, double>::init)
+        .def("next", &TreeIterator<D, double>::next);
 }
 } // namespace vampyr


### PR DESCRIPTION
I set all template parameters <T>  to double. 
We need to add complex type later, but I think that should be done with a redesign of the code.

I'll need to discuss with Valentyn what that should look like. 

There where some issues with the overload cast and the new template parameter. I worked around that
by using lambda functions instead. If we change our minds on this we can always track back on it.

At least vampyr should work now for mrcpp v2 

 